### PR TITLE
Fix no-mixed-operators lint warnings

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -482,7 +482,7 @@ var zoomPlugin = {
 			chartInstance.$zoom._dragZoomStart = null;
 			chartInstance.$zoom._dragZoomEnd = null;
 
-			var zoomThreshold = options.zoom && options.zoom.threshold || 0;
+			var zoomThreshold = (options.zoom && options.zoom.threshold) || 0;
 			if (dragDistanceX <= zoomThreshold && dragDistanceY <= zoomThreshold) {
 				return;
 			}


### PR DESCRIPTION
On chartjs-plugin-zoom.js
  493:37  warning  Unexpected mix of '&&' and '||'  no-mixed-operators
  493:63  warning  Unexpected mix of '&&' and '||'  no-mixed-operators

✖ 2 problems (0 errors, 2 warnings)